### PR TITLE
Increase API page size to maximum supported

### DIFF
--- a/resources/kds.ex-ca-rally/templates/api.json
+++ b/resources/kds.ex-ca-rally/templates/api.json
@@ -27,7 +27,7 @@
 	},
 	"pagination": {
 		"method": "offset",
-		"limit": 200,
+		"limit": 2000,
 		"limitParam": "pagesize",
 		"offsetParam": "start",
 		"offsetFromJob": true


### PR DESCRIPTION
Current Rally config uses API v2 which supports 2000 page limit. This will significantly lower the extraction time