### PR TITLE
add missing mapping for custom_fields -> tickets_fields_values table

### DIFF
--- a/resources/keboola.ex-zendesk/templates/config/01-basic.json
+++ b/resources/keboola.ex-zendesk/templates/config/01-basic.json
@@ -501,6 +501,28 @@
             "destination": "via_channel"
           }
         },
+        "custom_fields": {
+          "type": "table",
+          "destination": "tickets_fields_values",
+          "parentKey": {
+            "primaryKey": true
+          },
+          "tableMapping": {
+            "id": {
+              "mapping": {
+                "destination": "tickets_fields_pk",
+                "primaryKey": true
+              }
+            },
+            "value": {
+              "forceType": "json",
+              "mapping": {
+                "destination": "value",
+                "primaryKey": true
+              }
+            }
+          }
+        },
         "satisfaction_rating": {
           "type": "table",
           "destination": "tickets_ratings",

--- a/resources/keboola.ex-zendesk/templates/config/02-tickets-only.json
+++ b/resources/keboola.ex-zendesk/templates/config/02-tickets-only.json
@@ -487,6 +487,28 @@
           "destination": "via_channel"
         }
       },
+      "custom_fields": {
+        "type": "table",
+        "destination": "tickets_fields_values",
+        "parentKey": {
+          "primaryKey": true
+        },
+        "tableMapping": {
+          "id": {
+            "mapping": {
+              "destination": "tickets_fields_pk",
+              "primaryKey": true
+            }
+          },
+          "value": {
+            "forceType": "json",
+            "mapping": {
+              "destination": "value",
+              "primaryKey": true
+            }
+          }
+        }
+      },
       "satisfaction_rating": {
         "type": "table",
         "destination": "tickets_ratings",


### PR DESCRIPTION
https://keboola.slack.com/archives/C02CGRFGU/p1549451003054700

klient stahuje data z ex-zendesk(generic template) ale netaha mu to tabulku `ticket_fields_values` ktora by tam podla dokumentacie mala byt(https://help.keboola.com/extractors/communication/zendesk/#18--tickets-fields-values). Ta sa zmazala v
https://github.com/keboola/kbc-ui-templates/commit/b667f023cae9b6f472c8f3ce433f8feace755159#diff-3bb21763f223b335c9cd499424cac67bL518

tato uprava vracia `tickets_fields_values` pridanim mappingu pre custom_fields pod tickets