### PR TITLE
fix: keboola.ex-youtube channels

### DIFF
--- a/resources/keboola.ex-youtube/templates/config/01-channels.json
+++ b/resources/keboola.ex-youtube/templates/config/01-channels.json
@@ -4,7 +4,7 @@
   "data": {
     "jobs": [
       {
-        "endpoint": "channels?managedByMe=true&part=snippet,contentDetails,statistics",
+        "endpoint": "channels?part=snippet,contentDetails,statistics",
         "dataType": "channels",
         "dataField": "items"
       }


### PR DESCRIPTION
`managedByMe=true` polo pouzite bez druheho potrebneho parametru `onBehalfOfContentOwner ` a nefungovalo to:

https://developers.google.com/youtube/v3/docs/channels/list
![ Job 525379175 2019-08-02 09-55-27](https://user-images.githubusercontent.com/1488015/62353813-c1ab2f80-b50b-11e9-950f-0acc75d6bf29.png)
