### PR TITLE
Drive-cx.ex-drive-cx - update licence text

### DIFF
--- a/resources/drive-cx.ex-drive-cx/templates/LICENSE
+++ b/resources/drive-cx.ex-drive-cx/templates/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Data Services CZ
+Copyright (c) 2020 DriveCX
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Vyšlo ze Zendesku. Byl tam problém s tím připravit PR na vyhození licence, tak tomu chci jít trochu naproti. Jde o tento PR https://github.com/keboola/kbc-ui-templates/pull/100

EDIT: tak spíš bude jen upraven text, ještě do upravím teda