### PR TITLE
Adding retryConfig param to the ex

### DIFF
--- a/resources/keboola.ex-github/templates/api.json
+++ b/resources/keboola.ex-github/templates/api.json
@@ -1,5 +1,14 @@
 {
     "baseUrl": "https://api.github.com/",
+    "retryConfig": {
+     "http": {
+      "retryHeader": "X-RetryAfter",
+      "codes": [
+       403
+      ]
+     },
+     "maxRetries": 14
+    },
     "authentication": {
       "type": "oauth20",
       "format": "json",


### PR DESCRIPTION
To be able to deploy and use more demanding templates, we need to implement retry policy, so the extractor is not failing with 403 error (which is happening when doing lots of API calls).
Config test: https://connection.keboola.com/admin/projects/6845/extractors/ex-generic-v2/586770230