### PR TITLE
Fix pagination method in API.json

### DIFF
--- a/resources/kds-team.ex-bitbucket/templates/api.json
+++ b/resources/kds-team.ex-bitbucket/templates/api.json
@@ -4,8 +4,8 @@
     },
     "baseUrl": "https://api.bitbucket.org/2.0/",
     "pagination": {
-        "method": "pagenum",
-        "pageParam": "page"
+        "method": "response.url",
+        "urlKey": "next"
     },
     "http": {
         "headers": {


### PR DESCRIPTION
Původní pagination vrácí z API errory, protože prázdná stránka u určitých endpointů vyhodí 400. Přes response.url to tu prázdnou stránku vůbec nezavolá a tím pádem 400 nenastane.
Otestováno zde: https://connection.keboola.com/admin/projects/6638/jobs/641216358