### PR TITLE
slack extractor - fix pagination

### DIFF
--- a/resources/keboola.ex-slack/templates/api.json
+++ b/resources/keboola.ex-slack/templates/api.json
@@ -15,13 +15,13 @@
     },
     "defaultOptions": {
       "params": {
-        "count": "1000"
+        "limit": "200"
       }
     }
   },
   "pagination": {
     "method": "response.param",
-    "responseParam": "messages.999.ts",
-    "queryParam": "latest"
+    "responseParam": "response_metadata.next_cursor",
+    "queryParam": "cursor"
   }
 }


### PR DESCRIPTION
Jira - https://keboola.atlassian.net/browse/COM-1633

From [Slack docs](https://api.slack.com/methods/users.list):

```
This method uses cursor-based pagination to make it easier to incrementally collect information.
To begin pagination, specify a limit value under 1000. We recommend no more than 200 results at a time.

Responses will include a top-level response_metadata attribute containing a next_cursor value.
By using this value as a cursor parameter in a subsequent request, along with limit, you may navigate through the collection page by virtual page.

```