### PR TITLE
Slack auth fix

### DIFF
--- a/resources/keboola.ex-slack/templates/api.json
+++ b/resources/keboola.ex-slack/templates/api.json
@@ -3,9 +3,14 @@
   "authentication": {
     "type": "oauth20",
     "format": "json",
-    "query": {
-      "token": {
-        "authorization": "data.access_token"
+    "Authorization": {
+        "function": "concat",
+        "args": [
+          "Bearer ",
+          {
+            "authorization": "data.access_token"
+          }
+        ]
       }
     }
   },

--- a/resources/keboola.ex-slack/templates/api.json
+++ b/resources/keboola.ex-slack/templates/api.json
@@ -1,32 +1,33 @@
 {
-  "baseUrl": "https://slack.com/api/",
-  "authentication": {
-    "type": "oauth20",
-    "format": "json",
-    "Authorization": {
-        "function": "concat",
-        "args": [
-          "Bearer ",
-          {
-            "authorization": "data.access_token"
-          }
-        ]
-      }
-    }
-  },
-  "http": {
-    "headers": {
-      "Accept": "application/json"
+    "baseUrl": "https://slack.com/api/",
+    "authentication": {
+        "type": "oauth20",
+        "format": "json",
+        "headers": {
+            "Authorization": {
+                "function": "concat",
+                "args": [
+                    "Bearer ",
+                    {
+                        "authorization": "data.access_token"
+                    }
+                ]
+            }
+        }
     },
-    "defaultOptions": {
-      "params": {
-        "limit": "200"
-      }
+    "http": {
+        "headers": {
+            "Accept": "application/json"
+        },
+        "defaultOptions": {
+            "params": {
+                "limit": "200"
+            }
+        }
+    },
+    "pagination": {
+        "method": "response.param",
+        "responseParam": "response_metadata.next_cursor",
+        "queryParam": "cursor"
     }
-  },
-  "pagination": {
-    "method": "response.param",
-    "responseParam": "response_metadata.next_cursor",
-    "queryParam": "cursor"
-  }
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/GMT-87 

Slack už nepovoluje query string autorizaci u nových appek - https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps

Testovací konfigurace po úpravě pro novou i původní appku:
- https://connection.keboola.com/admin/projects/4088/queue/1065881110
- https://connection.europe-west3.gcp.keboola.com/admin/projects/6/queue/7303