### PR TITLE
fix: update LinkedIn Marketing API version from 202504 to 202603 (CFTL-301)

### DIFF
--- a/resources/leochan.ex-linkedin/templates/api.json
+++ b/resources/leochan.ex-linkedin/templates/api.json
@@ -4,7 +4,7 @@
         "type": "oauth20",
         "format": "json",
         "headers": {
-            "Linkedin-Version": "202504",
+            "Linkedin-Version": "202603",
             "Authorization": {
                 "function": "concat",
                 "args": [


### PR DESCRIPTION
## Summary

LinkedIn sunset Marketing API version 202504 on April 15, 2026, causing **all `leochan.ex-linkedin` jobs to fail** with `HTTP 426 Upgrade Required`:

```
{"status":426,"code":"NONEXISTENT_VERSION","message":"Requested version 20250401 is not active"}
```

This PR updates the `Linkedin-Version` header from `202504` → `202603` in `api.json`.

### What was checked and NOT changed

| Area | Status | Details |
|------|--------|---------|
| **API version header** | **Changed** | `202504` → `202603` |
| **Pagination** | Already correct | Scrollers already use cursor-based `response.param` with `pageToken` / `metadata.nextPageToken`. No `start`/`count` params found anywhere. |
| **Base URL** | Already correct | Already `https://api.linkedin.com/rest/` (not `/v2/`). |
| **Field names** | No changes needed | Reviewed [v202603 changelog](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes?view=li-lms-2026-03) — no field renames affecting adAccounts, adCampaigns, or adAnalytics endpoints. |

### Why v202603 and not v202604

v202603 (March 2026) is stable and confirmed working. v202604 was just released — v202603 is the safe target per the reporter's testing.

**Verified**: The reporter tested the v202603 header change in debug mode and the next job succeeded: [successful job run](https://connection.eu-central-1.keboola.com/admin/projects/3482/branch/15906/queue/984161402).

**Linear**: https://linear.app/keboola/issue/CFTL-301/linkedin-ads-extractor

## Review & Testing Checklist for Human

- [ ] Verify that a `leochan.ex-linkedin` job succeeds after this change is deployed (e.g. run a job in the test project linked above)
- [ ] Confirm pagination still works correctly for accounts with many ad campaigns (cursor-based pagination was already in place, but worth validating)

### Notes

- Previous version migration (202304 → 202404) was done in PR #174
- All pushes to `main` are automatically deployed per the README

## Release Notes
**Justification, description**

Emergency fix: LinkedIn sunset API version 202504 on 2026-04-15, breaking all `leochan.ex-linkedin` extractor jobs. Updates version header to 202603.

**Plans for Customer Communication**

Notify affected customers that the fix has been deployed and jobs should resume working.

**Impact Analysis**

All customers using the LinkedIn Ads extractor (`leochan.ex-linkedin`) are affected — jobs fail with HTTP 426. This is a P1 incident.

**Deployment Plan**

Merge to `main` — auto-deployed per repo workflow.

**Rollback Plan**

Revert the single-line change in `api.json` back to `202504` (though this would re-break all jobs).

**Post-Release Support Plan**

Monitor job success rates for `leochan.ex-linkedin` after deployment.

Link to Devin session: https://app.devin.ai/sessions/3870d0f02f884ce084bdf98e5ad457bd
Requested by: @terezaskalova